### PR TITLE
8 implement edge and node classification network

### DIFF
--- a/grace/models/classifier.py
+++ b/grace/models/classifier.py
@@ -9,7 +9,13 @@ from torch_geometric.nn import GCNConv, global_mean_pool
 class GCN(torch.nn.Module):
     """A graph convolutional network for subgraph classification."""
 
-    def __init__(self, input_channels: int, hidden_channels: int, *, output_classes: int = 2):
+    def __init__(
+        self,
+        input_channels: int,
+        hidden_channels: int,
+        *,
+        output_classes: int = 2,
+    ):
         super(GCN, self).__init__()
         torch.manual_seed(12345)
         self.conv1 = GCNConv(input_channels, hidden_channels)
@@ -28,7 +34,9 @@ class GCN(torch.nn.Module):
         x = self.conv2(x, edge_index)
         x = x.relu()
         embeddings = self.conv3(x, edge_index)
-        x = global_mean_pool(embeddings, batch)  # [batch_size, hidden_channels]
+        x = global_mean_pool(
+            embeddings, batch
+        )  # [batch_size, hidden_channels]
         x = F.dropout(x, p=0.5, training=self.training)
         x = self.linear(x)
         return x, embeddings

--- a/grace/models/classifier.py
+++ b/grace/models/classifier.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Tuple, Optional
 
 import torch
 import torch.nn.functional as F
@@ -7,48 +7,28 @@ from torch_geometric.nn import GCNConv, global_mean_pool
 
 
 class GCN(torch.nn.Module):
-    """A graph convolutional network for subgraph classification.
+    """A graph convolutional network for subgraph classification."""
 
-    Parameters
-    ----------
-    input_dims : int
-        The dimensions of the input.
-    embedding_dims : int
-        The dimensions of the hidden embeddings.
-    output_dims : int
-        The dimensions of the output. This is typically the number of classes in
-        the classifcation task.
-
-    """
-
-    def __init__(
-        self,
-        *,
-        input_dims: int = 3,
-        embedding_dims: int = 64,
-        output_dims: int = 2,
-    ) -> None:
+    def __init__(self, input_channels: int, hidden_channels: int, *, output_classes: int = 2):
         super(GCN, self).__init__()
-        # torch.manual_seed(12345)
-        self.conv1 = GCNConv(input_dims, embedding_dims)
-        self.conv2 = GCNConv(embedding_dims, embedding_dims)
-        self.conv3 = GCNConv(embedding_dims, embedding_dims)
-        self.linear = Linear(embedding_dims, output_dims)
+        torch.manual_seed(12345)
+        self.conv1 = GCNConv(input_channels, hidden_channels)
+        self.conv2 = GCNConv(hidden_channels, hidden_channels)
+        self.conv3 = GCNConv(hidden_channels, hidden_channels)
+        self.linear = Linear(hidden_channels, output_classes)
 
     def forward(
         self,
         x: torch.Tensor,
         edge_index: torch.Tensor,
         batch: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
+    ) -> Tuple[torch.Tensor]:
         x = self.conv1(x, edge_index)
         x = x.relu()
         x = self.conv2(x, edge_index)
         x = x.relu()
         embeddings = self.conv3(x, edge_index)
-
-        # node/subgraph classification
-        x = global_mean_pool(embeddings, batch)  # [batch_size, embedding_dims]
+        x = global_mean_pool(embeddings, batch)  # [batch_size, hidden_channels]
         x = F.dropout(x, p=0.5, training=self.training)
         x = self.linear(x)
-        return x
+        return x, embeddings

--- a/grace/models/datasets.py
+++ b/grace/models/datasets.py
@@ -54,6 +54,9 @@ def dataset_from_graph(
         )
         edge_attr = pos - central_node
 
+        edge_label = [edge[GraphAttrs.EDGE_GROUND_TRUTH]
+                      for _,edge in sub_graph.edges(data=True)]
+
         item = nx.convert_node_labels_to_integers(sub_graph)
         edges = list(item.edges)
         edge_index = torch.tensor(edges, dtype=torch.long).t().contiguous()
@@ -62,6 +65,7 @@ def dataset_from_graph(
             x=torch.Tensor(x),
             edge_index=edge_index,
             edge_attr=torch.Tensor(edge_attr),
+            edge_label=torch.Tensor(edge_label),
             pos=torch.Tensor(pos),
             y=torch.as_tensor([values[GraphAttrs.NODE_GROUND_TRUTH]]),
         )

--- a/grace/models/datasets.py
+++ b/grace/models/datasets.py
@@ -54,8 +54,10 @@ def dataset_from_graph(
         )
         edge_attr = pos - central_node
 
-        edge_label = [edge[GraphAttrs.EDGE_GROUND_TRUTH]
-                      for _,edge in sub_graph.edges(data=True)]
+        edge_label = [
+            edge[GraphAttrs.EDGE_GROUND_TRUTH]
+            for _, edge in sub_graph.edges(data=True)
+        ]
 
         item = nx.convert_node_labels_to_integers(sub_graph)
         edges = list(item.edges)

--- a/grace/models/train.py
+++ b/grace/models/train.py
@@ -40,7 +40,7 @@ def train_model(
         edge_score = (pred[src] * pred[dst]).sum(dim=-1)
 
         if target == Annotation.UNKNOWN:
-            return torch.tensor([0.])
+            return torch.tensor([0.0])
         else:
             return F.cross_entropy(edge_score, target)
 
@@ -50,7 +50,9 @@ def train_model(
         for data in train_loader:
             out_x, out_embedding = model(data.x, data.edge_index, data.batch)
             loss_node = node_criterion(out_x, data.y)
-            loss_edge = edge_criterion(out_embedding, data.edge_label, data.edge_index)
+            loss_edge = edge_criterion(
+                out_embedding, data.edge_label, data.edge_index
+            )
 
             loss = loss_node + loss_edge
 
@@ -65,7 +67,9 @@ def train_model(
         correct = 0
         for data in loader:
             out_x, out_embedding = model(data.x, data.edge_index, data.batch)
-            pred = out_x.argmax(dim=1)  # Use the class with highest probability.
+            pred = out_x.argmax(
+                dim=1
+            )  # Use the class with highest probability.
             correct += int((pred == data.y).sum())
 
         return correct / len(loader.dataset)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3,18 +3,18 @@ from grace.models.classifier import GCN
 import pytest
 
 
-@pytest.mark.parametrize("input_dims", [1, 2, 4])
-@pytest.mark.parametrize("embedding_dims", [16, 32, 64])
-@pytest.mark.parametrize("output_dims", [1, 2, 4])
-def test_model_building(input_dims, embedding_dims, output_dims):
+@pytest.mark.parametrize("input_channels", [1, 2, 4])
+@pytest.mark.parametrize("hidden_channels", [16, 32, 64])
+@pytest.mark.parametrize("output_classes", [1, 2, 4])
+def test_model_building(input_channels, hidden_channels, output_classes):
     """Test building the model with different dimension."""
 
     model = GCN(
-        input_dims=input_dims,
-        embedding_dims=embedding_dims,
-        output_dims=output_dims,
+        input_channels=input_channels,
+        hidden_channels=hidden_channels,
+        output_classes=output_classes,
     )
 
-    assert model.conv1.in_channels == input_dims
-    assert model.linear.in_features == embedding_dims
-    assert model.linear.out_features == output_dims
+    assert model.conv1.in_channels == input_channels
+    assert model.linear.in_features == hidden_channels
+    assert model.linear.out_features == output_classes

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,0 +1,4 @@
+from grace.models.classifier import GCN
+
+import pytest
+

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,4 +1,0 @@
-from grace.models.classifier import GCN
-
-import pytest
-


### PR DESCRIPTION
Still in a sort-of conceptual stage.

What's been done
- Changed `GCN` to output `x, embedding ` rather than just `x`.
- Adapted the `torch_geometric.data.Data` files to also include `edge_label`
- Added an `edge_criterion` loss to `train.py`

Questions
- Should `edge_criterion` be made to be a subclass of `_WeightedLoss`, or is it alright to keep it as a bare function?

What's not been done (yet)
- Changing `.test()` method to output edge classification results
- Tests (will probably do this after #64 has been merged)