### PR TITLE
Visualisation of the image & graph annotations

### DIFF
--- a/grace/napari/utils.py
+++ b/grace/napari/utils.py
@@ -67,7 +67,7 @@ def cut_graph_using_mask(
     mask : array
         A binary mask to filter points and edges in the graph.
     update_graph : bool, (default: True)
-        Update edge attributes in place.
+        Update node & edge attributes in place.
 
     Returns
     -------

--- a/grace/utils/metrics.py
+++ b/grace/utils/metrics.py
@@ -33,8 +33,8 @@ def confusion_matrix_metric(
     edge_pred: torch.Tensor,
     node_true: torch.Tensor,
     edge_true: torch.Tensor,
-    node_classes: List[str] = ["TP", "TN"],
-    edge_classes: List[str] = ["TP", "TN"],
+    node_classes: List[str] = ["TN_node", "TP_node"],
+    edge_classes: List[str] = ["TN_edge", "TP_edge"],
     figsize: Tuple[int] = (6, 5),
 ) -> Tuple[plt.Figure]:
     node_pred_labels = node_pred.argmax(dim=-1)


### PR DESCRIPTION
When reviewing, please annotate an image in *napari* & then visualise it using the `read_grace.ipynb` notebook

**Data processing:**
- [x] Comments out the inflammatory `astype(int)` from the image processing. Mentioned in #148 
- [x] When annotating in napari, marks the protruding nodes forming an TN edge as TN node. Discussed in #143 
- [x] When annotating in napari, sets the contrast range of the image to min / max value. Resolves #108

**Plotting / visualisation:**
- [x] Visualise the grace annotations overlaid on the image.
- [x] Display a montage & average image per classifier training class.
- [x] Plots simple graph & identifies isolated objects (i.e. connected components)

**Graph analysis:**
- [x] Generates a ground truth (GT) graph to allow metric calculation
- [x] Maintains all node & edge attributes in new GT graph: resolves #158 
- [x] Shortlists visualisation options in `read_grace.ipynb` notebook: resolves #136 